### PR TITLE
Added SSL config to 10-base.conf

### DIFF
--- a/bin/conf/system/10-base.conf
+++ b/bin/conf/system/10-base.conf
@@ -20,6 +20,7 @@ topaz {
   kernel-service {
     auth-file = "/opt/topaz/conf/auth.conf"
     getdown.jars-path = "/opt/topaz/lib"
+    ssl.directory = "/topaz/topaz/conf/ssl"
 
     licenses {
       server-path = "/opt/topaz/licenses"

--- a/bin/test-conf/system/10-base.conf
+++ b/bin/test-conf/system/10-base.conf
@@ -29,16 +29,14 @@ topaz {
   kernel-service {
     auth-file = "/opt/topaz/conf/auth.conf"
     getdown.jars-path = "/opt/topaz/lib"
+    ssl.directory = "/topaz/topaz/conf/ssl"
 
     licenses {
       server-path = "/opt/topaz/licenses"
       client-path = ${topaz.kernel-service.licenses.server-path}
     }
 
-    reports {
-      report-timeout = 60 m
-      report-runner-timeout = 60 m
-    }
+    reports.report-timeout = 60 m
   }
 
   excel.trade-xl.upload-system-with-delete-enabled = true


### PR DESCRIPTION
- Also we don't need additional report runner timeout override in test conf, that & the distributed MC now default to the overall report timeout.