### PR TITLE
Removed default config

### DIFF
--- a/bin/conf/application.vmoptions
+++ b/bin/conf/application.vmoptions
@@ -1,3 +1,3 @@
 -Xms4g
 -Xmx16g
--verbose:gc
+-Xlog:gc

--- a/bin/conf/system/10-base.conf
+++ b/bin/conf/system/10-base.conf
@@ -28,25 +28,7 @@ topaz {
     com.topaz.kernel.ReplModule
   ]
 
-  kernel-service {
-    getdown.jars-path = "/opt/topaz/lib"
-    ssl.directory = "/opt/topaz/conf/ssl"
-
-    auth.server-session-secret {
-      file = "/opt/topaz/conf/server-token-secret"
-      generate-if-missing = true
-    }
-
-    licenses {
-      server-path = "/opt/topaz/licenses"
-      client-path = ${topaz.kernel-service.licenses.server-path}
-    }
-  }
+  http-service.auth.server-session-secret.generate-if-missing = true
 
   repl-service.bind-address = "0.0.0.0"
-
-  pivot-store {
-    byte-buffer-directory = "/opt/topaz/data/transaction-byte-buffers"
-    blotter-byte-buffer-directory = "/opt/topaz/data/transaction-byte-buffers-blotter"
-  }
 }

--- a/bin/test-conf/application.vmoptions
+++ b/bin/test-conf/application.vmoptions
@@ -1,3 +1,3 @@
 -Xms2g
 -Xmx8g
--verbose:gc
+-Xlog:gc

--- a/bin/test-conf/system/10-base.conf
+++ b/bin/test-conf/system/10-base.conf
@@ -28,29 +28,11 @@ topaz {
     com.topaz.kernel.ReplModule
   ]
 
-  kernel-service {
-    getdown.jars-path = "/opt/topaz/lib"
-    ssl.directory = "/opt/topaz/conf/ssl"
-
-    auth.server-session-secret {
-      file = "/opt/topaz/conf/server-token-secret"
-      generate-if-missing = true
-    }
-
-    licenses {
-      server-path = "/opt/topaz/licenses"
-      client-path = ${topaz.kernel-service.licenses.server-path}
-    }
-
-    reports.report-timeout = 60 m
-  }
-
   excel.trade-xl.upload-system-with-delete-enabled = true
 
-  repl-service.bind-address = "0.0.0.0"
+  http-service.auth.server-session-secret.generate-if-missing = true
 
-  pivot-store {
-    byte-buffer-directory = "/opt/topaz/data/transaction-byte-buffers"
-    blotter-byte-buffer-directory = "/opt/topaz/data/transaction-byte-buffers-blotter"
-  }
+  kernel-service.reports.report-timeout = 60 m
+
+  repl-service.bind-address = "0.0.0.0"
 }

--- a/compose/cassandra-redis-topaz-linux.yml
+++ b/compose/cassandra-redis-topaz-linux.yml
@@ -1,18 +1,6 @@
 version: '3'
 
 services:
-  consul:
-    image: topaztechnology/consul:1.0.6
-    hostname: consul
-    restart: always
-    ports:
-    - 8500:8500
-    volumes:
-    - consul-data:/consul/data
-    environment:
-      LOG_LEVEL: INFO
-      CONSUL_TYPE: server
-
   cassandra:
     image: cassandra:3.11
     hostname: cassandra

--- a/compose/cassandra-redis-topaz-localhost.yml
+++ b/compose/cassandra-redis-topaz-localhost.yml
@@ -1,18 +1,6 @@
 version: '3'
 
 services:
-  consul:
-    image: topaztechnology/consul:1.0.6
-    hostname: consul
-    restart: always
-    ports:
-    - 8500:8500
-    volumes:
-    - consul-data:/consul/data
-    environment:
-      LOG_LEVEL: INFO
-      CONSUL_TYPE: server
-
   cassandra:
     image: cassandra:3.11
     hostname: cassandra


### PR DESCRIPTION
- There was a lot of default config that was being specified which is identical (now) to config in prod resources, that was stripped out
- We no longer use Consul for service discovery, so that was removed
- Updated vmoptions for Java 11